### PR TITLE
fix some build errors on Debian 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ all: $(PROGNAME)
 ifneq ($(RELEASE),y)
 
 %.o: %.c $(INCS) Makefile
-	gcc $(CFLAGS) -Werror -c -o $@ $< `pkg-config --cflags libglade-2.0 gmodule-2.0 alsa` -DUI_DIR=\"$(UI_DIR)\" -g -O2
+	gcc $(CFLAGS) -Werror -Wno-error=deprecated-declarations -c -o $@ $< `pkg-config --cflags libglade-2.0 gmodule-2.0 alsa` -DUI_DIR=\"$(UI_DIR)\" -g -O2
 
 $(PROGNAME): $(OBJS)
 	@echo $(OBJS)

--- a/debug.h
+++ b/debug.h
@@ -37,7 +37,7 @@ int xprintf(const char *fmt, ...);
 #define eprintf(...) fprintf(stderr, __VA_ARGS__)
 
 /* Global debug enable/disable */
-int debug;
+extern int debug;
 
 #endif /* _DEBUG_H_ */
 

--- a/midi.c
+++ b/midi.c
@@ -20,7 +20,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  ****************************************************************************/
 
-#include <asoundlib.h>
+#include <alsa/asoundlib.h>
 
 #include "midi.h"
 #include "debug.h"


### PR DESCRIPTION
I've tried to build xtor on current Debian stable (Debian 11 aka. Bullseye) and ran into some compile errors.
These small fixes make the build pass.